### PR TITLE
CI: Fix warnings & deprecation messages in the workflows and enable DependaBot for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
   pull_request:
-  workflow_dispatch:
 
 jobs:
   build-java:
@@ -11,7 +10,7 @@ jobs:
     # Jobs that depend on this one will be skipped too.
     # This prevents duplicate CI runs for our own pull requests, whilst preserving the ability to
     # run the CI for each branch push to a fork, and for each pull request originating from a fork.
-    # if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -128,7 +127,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       # Only run this step for main and hotfix branches.
       - name: Upload Docker image
-        # if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v4
         with:
           name: docker-${{ matrix.component }}
@@ -196,7 +195,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       # Only run this step for main and hotfix branches.
       - name: Upload Docker image
-        # if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v4
         with:
           name: docker-${{ matrix.component }}
@@ -207,7 +206,7 @@ jobs:
     # Jobs that depend on this one will be skipped too.
     # This prevents duplicate CI runs for our own pull requests, whilst preserving the ability to
     # run the CI for each branch push to a fork, and for each pull request originating from a fork.
-    # if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -278,7 +277,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       # Only run this step for main and hotfix branches.
       - name: Upload Docker image
-        # if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v4
         with:
           name: docker-config-editor-ui
@@ -287,7 +286,7 @@ jobs:
   release-version:
     # Only run this job for main and hotfix branches.
     # Jobs that depend on this one will be skipped too.
-    # if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
+    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
     runs-on: ubuntu-latest
     needs: build-java
     outputs:
@@ -341,7 +340,7 @@ jobs:
   release-docker:
     # Only run this job for main and hotfix branches.
     # Jobs that depend on this one will be skipped too.
-    # if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
+    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
     runs-on: ubuntu-latest
     needs: [build-docker-storm, build-docker-java, build-docker-config-editor-ui]
     environment: release
@@ -367,7 +366,7 @@ jobs:
   event_file:
     name: "Event File"
     needs: build-java
-    # if: always() && needs.build-java.result != 'skipped'
+    if: always() && needs.build-java.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
       - name: Upload

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,8 +19,7 @@ on:
     branches: [ main ]
   # Run schedule at 04:00 on Monday.
   schedule:
-    - cron: '0 4 * * 1'
-  workflow_dispatch:
+    - cron: '0 4 * * 1' 
 
 jobs:
   analyze:

--- a/.github/workflows/unit-test-results.yml
+++ b/.github/workflows/unit-test-results.yml
@@ -5,13 +5,12 @@ on:
     workflows: ["CI"]
     types:
       - completed
-  workflow_dispatch:
 
 jobs:
   unit-test-results:
     name: Unit Test Results
     runs-on: ubuntu-latest
-    # if: github.event.workflow_run.conclusion != 'skipped'
+    if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
       # we are not using actions/download-artifact here as


### PR DESCRIPTION
#### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

#### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Bump the steps where deprecation/warnings are shown in the job ([commit](https://github.com/gr-oss-devops/siembol/pull/1/commits/df1aacabdea2b51cb872a4a7c4acde4876712e72))


#### Which issue(s) this PR fixes:

https://github.com/G-Research/gr-oss/issues/632

------------

# Testing results

As the desired state is that a job should run without warnings/deprecation messages shown, in this [commit](https://github.com/gr-oss-devops/siembol/pull/1/commits/3f9e556261e7a2a53907e15c740c894c37b25b0e) I removed some of the conditions in the workflow to test them and their actions and below is the results for each workflow where deprecation warnings are shown

## PASSED 🟢 

**CI**
 - https://github.com/gr-oss-devops/siembol/actions/runs/8482685041 - No deprecation/warnings shown

**CodeQL** 
 - https://github.com/gr-oss-devops/siembol/actions/runs/8482685238

**Unit test results**
 - https://github.com/gr-oss-devops/siembol/actions/runs/8482708915 - No deprecation/warnings shown